### PR TITLE
Fix: fit RoomsList into viewport on mobile

### DIFF
--- a/src/lib/RoomsList/RoomsList.vue
+++ b/src/lib/RoomsList/RoomsList.vue
@@ -1,8 +1,8 @@
 <template>
 	<div
 		v-show="showRoomsList"
-		class="vac-rooms-container vac-app-border-r"
-		:class="{ 'vac-rooms-container-full': isMobile }"
+		class="vac-rooms-container"
+		:class="{ 'vac-rooms-container-full': isMobile, 'vac-app-border-r': !isMobile }"
 	>
 		<slot name="rooms-header" />
 


### PR DESCRIPTION
There was a slight viewport overflow caused by the border on the right side in full-width mobile view of RoomsList.

**What kind of change does this PR introduce?** (check at least one)

- [x] Bugfix

**Does this PR introduce a breaking change?** (check one)

- [x] No

If adding a **new feature**, the PR's description includes:

- [x] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
